### PR TITLE
Refactor rental order workflow

### DIFF
--- a/client/src/App/customer/rentals/page.jsx
+++ b/client/src/App/customer/rentals/page.jsx
@@ -15,22 +15,21 @@ const RentalsPage = () => {
       rentalTemplate: 'Standard Rental',
       expiration: '2024-02-15',
       rentalOrderDate: '2024-01-15',
-      priceList: 'Standard',
-      rentalPeriod: '30 days',
-      rentalDuration: '1 month',
+      rentalDuration: '1 months, 0 days, 0 hours',
       items: [
         {
           product: 'Product 1',
           quantity: 5,
           unitPrice: 200,
-          tax: 0,
-          subTotal: 1000
+          subTotal: 1000,
+          tax: 1000 * 0.18
         }
       ],
-      termsConditions: 'Standard terms and conditions apply for this rental agreement.',
+      termsConditions:
+        'Extra charges apply for late return. Equipment must be returned in its original condition.',
       untaxedTotal: 1000,
-      tax: 0,
-      total: 1000,
+      tax: 1000 * 0.18,
+      total: 1000 + 1000 * 0.18,
       status: 'confirmed',
       deliveryStatus: '2. Delivery'
     }

--- a/client/src/components/ConfirmedRentalForm.jsx
+++ b/client/src/components/ConfirmedRentalForm.jsx
@@ -128,18 +128,6 @@ const ConfirmedRentalForm = ({ order }) => {
               </div>
             </div>
             <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1">Price List:</label>
-              <div className="w-full px-3 py-2 bg-gray-50 border border-gray-300 rounded-md text-gray-900">
-                {order.priceList}
-              </div>
-            </div>
-            <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1">Rental Period:</label>
-              <div className="w-full px-3 py-2 bg-gray-50 border border-gray-300 rounded-md text-gray-900">
-                {order.rentalPeriod}
-              </div>
-            </div>
-            <div>
               <label className="block text-sm font-medium text-gray-700 mb-1">Rental Duration:</label>
               <div className="w-full px-3 py-2 bg-gray-50 border border-gray-300 rounded-md text-gray-900">
                 {order.rentalDuration}
@@ -193,7 +181,7 @@ const ConfirmedRentalForm = ({ order }) => {
                     <td className="px-4 py-2 bg-gray-50">{item.product}</td>
                     <td className="px-4 py-2 bg-gray-50">{item.quantity}</td>
                     <td className="px-4 py-2 bg-gray-50">{item.unitPrice}</td>
-                    <td className="px-4 py-2 bg-gray-50">{item.tax}</td>
+                    <td className="px-4 py-2 bg-gray-50">{Number(item.tax).toFixed(2)}</td>
                     <td className="px-4 py-2 bg-gray-50 font-medium">{item.subTotal}</td>
                   </tr>
                 ))}


### PR DESCRIPTION
## Summary
- streamline rental form by removing price list and rental period fields
- add month/day/hour duration inputs with automatic 18% tax calculation
- enforce terms acceptance and trigger order creation from header button

## Testing
- `npm test` (client) *(fails: Missing script: "test")*
- `npm run lint` (client) *(fails: no-unused-vars, react-refresh/only-export-components)*
- `npm test` (server) *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689a506d43888320b73c3a6a8adb7e0b