### PR TITLE
Add wishlist feature and redirect root to login

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { BrowserRouter as Router, Routes, Route, Navigate } from 'react-router-dom';
 import { AuthProvider } from './contexts/AuthContext';
+import { WishlistProvider } from './contexts/WishlistContext';
 import ProtectedRoute from './components/ProtectedRoute';
 import LoginPage from './App/auth/login/page';
 import SignupPage from './App/auth/signup/page';
@@ -13,6 +14,7 @@ import UnauthorizedPage from './pages/UnauthorizedPage';
 import RentalsPage from './App/customer/rentals/page';
 import RentalShopPage from './App/customer/products/page';
 import ProductDetailsPage from './App/customer/products/[productId]/page';
+import WishlistPage from './App/customer/wishlist/page';
 import ReviewOrderPage from './App/customer/checkout/review/page';
 import DeliveryPage from './App/customer/checkout/delivery/page';
 import PaymentPage from './App/customer/checkout/payment/page';
@@ -29,9 +31,10 @@ import AdminOrders from './App/admin/orders/page';
 function App() {
   return (
     <AuthProvider>
-      <Router>
-        <div className="App">
-          <Routes>
+      <WishlistProvider>
+        <Router>
+          <div className="App">
+            <Routes>
             {/* Public routes */}
             <Route path="/login" element={<LoginPage />} />
             <Route path="/signup" element={<SignupPage />} />
@@ -65,6 +68,14 @@ function App() {
               element={
                 <ProtectedRoute requiredRole="customer">
                   <ProductDetailsPage />
+                </ProtectedRoute>
+              }
+            />
+            <Route
+              path="/wishlist"
+              element={
+                <ProtectedRoute requiredRole="customer">
+                  <WishlistPage />
                 </ProtectedRoute>
               }
             />
@@ -135,13 +146,14 @@ function App() {
             </Route>
             
             {/* Default redirect */}
-            <Route path="/" element={<Navigate to="/products" replace />} />
-            
+            <Route path="/" element={<Navigate to="/auth/login" replace />} />
+
             {/* Catch all route */}
-            <Route path="*" element={<Navigate to="/products" replace />} />
-          </Routes>
-        </div>
-      </Router>
+            <Route path="*" element={<Navigate to="/auth/login" replace />} />
+            </Routes>
+          </div>
+        </Router>
+      </WishlistProvider>
     </AuthProvider>
   );
 }

--- a/client/src/App/customer/products/[productId]/page.jsx
+++ b/client/src/App/customer/products/[productId]/page.jsx
@@ -1,12 +1,14 @@
 import React, { useState, useEffect } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { useAuth } from '../../../../contexts/AuthContext';
+import { useWishlist } from '../../../../contexts/WishlistContext';
 import api from '../../../../lib/api';
 
 const ProductDetailsPage = () => {
   const { productId } = useParams();
   const { user } = useAuth();
   const navigate = useNavigate();
+  const { toggleWishlist, isWishlisted } = useWishlist();
   
   // Product and rental state
   const [product, setProduct] = useState(null);
@@ -188,8 +190,9 @@ const ProductDetailsPage = () => {
   };
 
   const handleWishlist = () => {
-    // Implement wishlist functionality
-    console.log('Added to wishlist:', product?.name);
+    if (product) {
+      toggleWishlist(product);
+    }
   };
 
   const getProductImage = (product, index = 0) => {
@@ -299,10 +302,15 @@ const ProductDetailsPage = () => {
                   onClick={handleWishlist}
                   className="w-full border-2 border-gray-300 text-gray-700 py-3 px-6 rounded-full font-medium hover:border-blue-600 hover:text-blue-600 transition-colors flex items-center justify-center space-x-2"
                 >
-                  <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <svg
+                    className={`w-5 h-5 ${isWishlisted(product?.id) ? 'text-red-500 fill-current' : ''}`}
+                    fill={isWishlisted(product?.id) ? 'currentColor' : 'none'}
+                    stroke="currentColor"
+                    viewBox="0 0 24 24"
+                  >
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z" />
                   </svg>
-                  <span>Add to wish list</span>
+                  <span>{isWishlisted(product?.id) ? 'Remove from wish list' : 'Add to wish list'}</span>
                 </button>
               </div>
             </div>

--- a/client/src/App/customer/products/page.jsx
+++ b/client/src/App/customer/products/page.jsx
@@ -2,10 +2,12 @@ import React, { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useAuth } from '../../../contexts/AuthContext';
 import api from '../../../lib/api';
+import { useWishlist } from '../../../contexts/WishlistContext';
 
 const RentalShopPage = () => {
   const { user } = useAuth();
   const navigate = useNavigate();
+  const { toggleWishlist, isWishlisted } = useWishlist();
   
   // Products and filtering state
   const [products, setProducts] = useState([]);
@@ -172,8 +174,8 @@ const RentalShopPage = () => {
           <div className="flex items-center justify-between h-16">
             {/* Navigation */}
             <nav className="flex items-center space-x-8">
-              <button 
-                onClick={() => navigate('/')}
+              <button
+                onClick={() => navigate('/products')}
                 className="text-gray-900 hover:text-blue-600 transition-colors"
               >
                 Home
@@ -438,9 +440,22 @@ const RentalShopPage = () => {
                         <div className="p-4 flex-1">
                           <div className="flex justify-between items-start mb-2">
                             <h3 className="font-semibold text-gray-900">{product.name}</h3>
-                            <button className="text-gray-400 hover:text-red-500 transition-colors">
-                              <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z" />
+                            <button
+                              onClick={() => toggleWishlist(product)}
+                              className="text-gray-400 hover:text-red-500 transition-colors"
+                            >
+                              <svg
+                                className={`w-5 h-5 ${isWishlisted(product.id) ? 'text-red-500 fill-current' : ''}`}
+                                fill={isWishlisted(product.id) ? 'currentColor' : 'none'}
+                                stroke="currentColor"
+                                viewBox="0 0 24 24"
+                              >
+                                <path
+                                  strokeLinecap="round"
+                                  strokeLinejoin="round"
+                                  strokeWidth={2}
+                                  d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z"
+                                />
                               </svg>
                             </button>
                           </div>

--- a/client/src/App/customer/wishlist/page.jsx
+++ b/client/src/App/customer/wishlist/page.jsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useWishlist } from '../../../contexts/WishlistContext';
+
+const WishlistPage = () => {
+  const { wishlist, removeFromWishlist } = useWishlist();
+  const navigate = useNavigate();
+
+  const getProductImage = (product) => {
+    if (product.images && product.images.length > 0) {
+      return product.images[0];
+    }
+    return `data:image/svg+xml;base64,${btoa(`<svg xmlns="http://www.w3.org/2000/svg" width="300" height="300" viewBox="0 0 300 300" fill="none"><rect width="300" height="300" fill="#E5E7EB"/><text x="50%" y="50%" text-anchor="middle" dy="0.3em" fill="#6B7280" font-family="Arial, sans-serif" font-size="80" font-weight="bold">${product.name?.charAt(0) || 'P'}</text></svg>`)}`;
+  };
+
+  if (wishlist.length === 0) {
+    return (
+      <div className="max-w-7xl mx-auto px-4 py-12 text-center">
+        <h2 className="text-2xl font-semibold text-gray-900 mb-4">Your wishlist is empty</h2>
+        <p className="text-gray-600 mb-6">Browse products and add them to your wishlist for later.</p>
+        <button
+          onClick={() => navigate('/products')}
+          className="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded-md"
+        >
+          Go to Products
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="max-w-7xl mx-auto px-4 py-8">
+      <h2 className="text-2xl font-semibold text-gray-900 mb-6">My Wishlist</h2>
+      <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+        {wishlist.map((product) => (
+          <div key={product.id} className="bg-white rounded-lg shadow-sm overflow-hidden flex flex-col">
+            <img
+              src={getProductImage(product)}
+              alt={product.name}
+              className="h-48 w-full object-cover"
+            />
+            <div className="p-4 flex-1 flex flex-col">
+              <h3
+                onClick={() => navigate(`/products/${product.id}`)}
+                className="font-semibold text-gray-900 mb-2 cursor-pointer hover:text-blue-600"
+              >
+                {product.name}
+              </h3>
+              <span className="text-lg font-bold text-green-600 mb-4">₹{product.pricePerDay}/day</span>
+              <button
+                onClick={() => removeFromWishlist(product.id)}
+                className="mt-auto border border-gray-300 text-gray-700 py-2 px-4 rounded-md text-sm hover:bg-gray-50"
+              >
+                Remove
+              </button>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default WishlistPage;
+

--- a/client/src/contexts/WishlistContext.jsx
+++ b/client/src/contexts/WishlistContext.jsx
@@ -1,0 +1,47 @@
+import React, { createContext, useContext, useState, useEffect } from 'react';
+
+const WishlistContext = createContext();
+
+export const WishlistProvider = ({ children }) => {
+  const [wishlist, setWishlist] = useState(() => {
+    try {
+      const stored = localStorage.getItem('wishlist');
+      return stored ? JSON.parse(stored) : [];
+    } catch {
+      return [];
+    }
+  });
+
+  useEffect(() => {
+    try {
+      localStorage.setItem('wishlist', JSON.stringify(wishlist));
+    } catch {
+      /* ignore */
+    }
+  }, [wishlist]);
+
+  const toggleWishlist = (product) => {
+    setWishlist((prev) => {
+      const exists = prev.some((item) => item.id === product.id);
+      if (exists) {
+        return prev.filter((item) => item.id !== product.id);
+      }
+      return [...prev, product];
+    });
+  };
+
+  const isWishlisted = (productId) => wishlist.some((item) => item.id === productId);
+
+  const removeFromWishlist = (productId) => {
+    setWishlist((prev) => prev.filter((item) => item.id !== productId));
+  };
+
+  return (
+    <WishlistContext.Provider value={{ wishlist, toggleWishlist, isWishlisted, removeFromWishlist }}>
+      {children}
+    </WishlistContext.Provider>
+  );
+};
+
+export const useWishlist = () => useContext(WishlistContext);
+


### PR DESCRIPTION
## Summary
- Redirect root and unknown routes to login instead of products
- Add persistent wishlist context and page
- Enable toggling wishlist items on product listing and detail pages

## Testing
- `npm test`
- `npm test` (server)
- `npm run lint` *(fails: no-unused-vars and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_689a8f02044c832093c1d8ba73526ee9