### PR TITLE
Redirect manage rentals to products

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -112,14 +112,6 @@ function App() {
               }
             />
             <Route
-              path="/rentals"
-              element={
-                <ProtectedRoute requiredRole="customer">
-                  <RentalsPage />
-                </ProtectedRoute>
-              }
-            />
-            <Route
               path="/my-rentals"
               element={
                 <ProtectedRoute requiredRole="customer">

--- a/client/src/pages/DashBoardPage.jsx
+++ b/client/src/pages/DashBoardPage.jsx
@@ -71,10 +71,10 @@ const DashboardPage = () => {
               {/* Quick Actions for Customer */}
               {user?.role === 'customer' && (
                 <div className="mb-6">
-                  <Link
-                    to="/rentals"
-                    className="inline-flex items-center px-6 py-3 bg-gradient-to-r from-primary-600 to-secondary-600 text-white font-semibold rounded-xl hover:from-primary-700 hover:to-secondary-700 transition-all duration-300 shadow-lg hover:shadow-xl transform hover:-translate-y-0.5"
-                  >
+                    <Link
+                      to="/products"
+                      className="inline-flex items-center px-6 py-3 bg-gradient-to-r from-primary-600 to-secondary-600 text-white font-semibold rounded-xl hover:from-primary-700 hover:to-secondary-700 transition-all duration-300 shadow-lg hover:shadow-xl transform hover:-translate-y-0.5"
+                    >
                     <svg className="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                       <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2" />
                     </svg>


### PR DESCRIPTION
## Summary
- Remove buggy `/rentals` route from client router
- Direct dashboard "Manage Rentals" button to `/products`

## Testing
- `npm test`
- `npm run lint` *(fails: no-unused-vars, react-refresh/only-export-components, no-extra-boolean-cast)*

------
https://chatgpt.com/codex/tasks/task_e_689a92785d50832097e10e1160c5215a