### PR TITLE
Add logout route after checkout payment

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -19,6 +19,7 @@ import ReviewOrderPage from './App/customer/checkout/review/page';
 import DeliveryPage from './App/customer/checkout/delivery/page';
 import PaymentPage from './App/customer/checkout/payment/page';
 import CheckoutSuccessPage from './App/customer/checkout/success/page';
+import LogoutPage from './pages/LogoutPage';
 
 // Admin Components
 import AdminLayout from './App/admin/layout';
@@ -100,6 +101,14 @@ function App() {
               element={
                 <ProtectedRoute requiredRole="customer">
                   <PaymentPage />
+                </ProtectedRoute>
+              }
+            />
+            <Route
+              path="/logout"
+              element={
+                <ProtectedRoute>
+                  <LogoutPage />
                 </ProtectedRoute>
               }
             />

--- a/client/src/pages/LogoutPage.jsx
+++ b/client/src/pages/LogoutPage.jsx
@@ -1,0 +1,24 @@
+import React, { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useAuth } from '../contexts/AuthContext';
+
+const LogoutPage = () => {
+  const { logout } = useAuth();
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    const handleLogout = async () => {
+      await logout();
+      navigate('/auth/login', { replace: true });
+    };
+    handleLogout();
+  }, [logout, navigate]);
+
+  return (
+    <div className="min-h-screen flex items-center justify-center">
+      <p className="text-neutral-600">Logging out...</p>
+    </div>
+  );
+};
+
+export default LogoutPage;


### PR DESCRIPTION
## Summary
- Add dedicated LogoutPage that logs out and redirects to login
- Register /logout protected route after checkout payment page

## Testing
- `npm test`
- `npm run lint` *(fails: no-unused-vars and other existing warnings/errors)*

------
https://chatgpt.com/codex/tasks/task_e_689a96a25d108320a1ce1bfa85b5dc23